### PR TITLE
discord rpc support

### DIFF
--- a/com.unicornsonlsd.finamp.yaml
+++ b/com.unicornsonlsd.finamp.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=pulseaudio
   - --filesystem=xdg-run/pipewire-0:ro
   - --share=network
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
 modules:
   - name: finamp
     buildsystem: simple


### PR DESCRIPTION
Implementation according to this guide: [https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)](https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc))
For now this probably only works with flatpak Discord if the user does what is described in the "Unsandboxed applications" section.
For full out-of-the-box support a wrapper script should be implemented in the future according to the guide.