### PR TITLE
Another hotfix for flatpak crashes

### DIFF
--- a/com.unicornsonlsd.finamp.yaml
+++ b/com.unicornsonlsd.finamp.yaml
@@ -45,13 +45,13 @@ modules:
         only-arches:
           - x86_64
         url: https://github.com/UnicornsOnLSD/finamp/releases/download/0.9.25-beta/finamp-0.9.25-beta-linux-x64.tar.gz
-        sha256: 87d1f6f3ac9d411ce0e63537c6422e932c1f00bca7cc91f7dcfae64ec01f6d5b
+        sha256: c18e6e3f3b62928b187cba84ad81361efaaedd1a265b78e2032ce7fd8254a8fe
         strip-components: 0
       - type: archive
         only-arches:
           - aarch64
         url: https://github.com/UnicornsOnLSD/finamp/releases/download/0.9.25-beta/finamp-0.9.25-beta-linux-arm64.tar.gz
-        sha256: 22be370e7cc1c445f27bf9a91a759013053ce445ac11abc4ecd5bd052a5a1d1c
+        sha256: b596bae1c48cbb44e7143172da7d1f17cf6682cb4a3afbacff469d28cc90a6f8
         strip-components: 0
       - type: file
         url: https://raw.githubusercontent.com/jmshrv/finamp/dac612650747e832e28690eb639faaff02f242c5/assets/icon/icon_foreground_square.svg


### PR DESCRIPTION
This time using Flutter beta to avoid issues with HTTPS connections